### PR TITLE
[Command] Stripping frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ It embeds your frameworks, their symbols, and the bcsymbolmap files into your bu
 
 ![Xcode build phase using the command to embed the frameworks](Assets/Frameworks-Embed.png)
 
+##### Strip
+It strips architectures from your frameworks:
+
+```
+xcode frameworks strip MyFramework.framework --archs armv7
+```
 
 ## References
 

--- a/Sources/Frameworks/StripCommand.swift
+++ b/Sources/Frameworks/StripCommand.swift
@@ -1,0 +1,40 @@
+import Foundation
+import PathKit
+import Core
+
+/// Strips architectures from a given framework.
+public class StripCommand {
+    
+    // MARK: - Attributes
+    
+    /// The package path.
+    private let packagePath: Path
+    
+    /// The architectures that will be stripped.
+    private let architecturesToStrip: Set<String>
+    
+    // MARK: - Init
+    
+    /// Default constructor.
+    ///
+    /// - Parameters:
+    ///   - packagePath: package path.
+    ///   - architecturesToStrip: architectures that will be stripped.
+    public init(packagePath: Path,
+                architecturesToStrip: Set<String>) {
+        self.packagePath = packagePath
+        self.architecturesToStrip = architecturesToStrip
+    }
+    
+    // MARK: - Func
+    
+    /// Executes the command.
+    ///
+    /// - Throws: an error if the architectures cannot be stripped.
+    public func execute() throws {
+        let package = Package(path: packagePath)
+        let architecturesToKeep = Set(package.architectures()).subtracting(architecturesToStrip)
+        try package.strip(keepingArchitectures: Array(architecturesToKeep))
+    }
+    
+}

--- a/Sources/Frameworks/StripCommand.swift
+++ b/Sources/Frameworks/StripCommand.swift
@@ -33,8 +33,8 @@ public class StripCommand {
     /// - Throws: an error if the architectures cannot be stripped.
     public func execute() throws {
         let package = Package(path: packagePath)
-        let architecturesToKeep = Set(package.architectures()).subtracting(architecturesToStrip)
-        try package.strip(keepingArchitectures: Array(architecturesToKeep))
+        let keepingArchitectures = Set(package.architectures()).subtracting(architecturesToStrip)
+        try package.strip(keepingArchitectures: Array(keepingArchitectures))
     }
     
 }

--- a/Sources/xcode/main.swift
+++ b/Sources/xcode/main.swift
@@ -13,7 +13,7 @@ enum XcodeError: Error {
 Group {
     $0.group("frameworks", "set of tools to work with frameworks in your project") { (frameworks) in
         let embedCommand = command(Flag("allconfigs", flag: "a", description: "Embed the frameworks for all the configurations", default: true),
-                                   Option("configs", "", flag: "c", description: "Array separated list of configs that need the framework to be embed (e.g. Debug,Release)")) { (buildAllConfigs: Bool, configs: String) in                                    
+                                   Option("configs", "", flag: "c", description: "Comma separated list of configs that need the framework to be embed (e.g. Debug,Release)")) { (buildAllConfigs: Bool, configs: String) in
                                     guard let environment = XcodeEnvironment() else{
                                         throw XcodeError.xcodeEnvironmentNotFound
                                     }
@@ -25,7 +25,12 @@ Group {
                                                      action: environment.action,
                                                      builtProductsDir: environment.builtProductsDir).execute()
         }
+        let stripCommand = command(Argument("path", description: "Framework path"),
+                                   Option("archs", "", flag: "a", description: "Comma separated list of architectures to strip (e.g. armv7,arm64)")) { (path: String, archs: String) in
+            try StripCommand(packagePath: Path(path), architecturesToStrip: Set(archs.components(separatedBy: ","))).execute()
+        }
         frameworks.addCommand("embed", "embeds frameworks into the product /Frameworks folder", embedCommand)
+        frameworks.addCommand("strip", "strip architectures from a given framework", stripCommand)
     }
     }.run()
 // swiftlint:enable line_length

--- a/Tests/FrameworksTests/EmbedCommandTests.swift
+++ b/Tests/FrameworksTests/EmbedCommandTests.swift
@@ -41,7 +41,6 @@ final class EmbedCommandTests: XCIntegrationTestCase {
                                validArchs: ["armv7"],
                                action: .install,
                                builtProductsDir: Path(outputPath()).parent().string)
-        try? Path(outputPath()).mkdir()
     }
     
     func test_execute_copiesTheFramework() {
@@ -84,11 +83,6 @@ final class EmbedCommandTests: XCIntegrationTestCase {
     func test_execute_copyTheBCSymbols_whenTheActionIsInstall() {
         try? subject.execute()
         XCTAssertEqual(Path(outputPath()).parent().glob("*.bcsymbolmap").count, 2)
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-        try? Path(outputPath()).delete()
     }
     
     private func inputPath() -> String {

--- a/Tests/FrameworksTests/StripCommandTests.swift
+++ b/Tests/FrameworksTests/StripCommandTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+import PathKit
+import Core
+import Frameworks
+import PathKit
+import TestsFoundation
+import Core
+
+
+// MARK: - StripCommandTests
+
+final class StripCommandTests: XCIntegrationTestCase {
+    
+    var subject: StripCommand!
+    
+    override func setUp() {
+        super.setUp()
+        subject = StripCommand(packagePath: outputPath(),
+                               architecturesToStrip: ["armv7"])
+    }
+    
+    func test_execute_stripsTheGivenArchitecture() {
+        try? inputPath().copy(outputPath())
+        XCTAssertEqual(Package(path: outputPath()).architectures(), ["armv7", "arm64"])
+        try? subject.execute()
+        XCTAssertEqual(Package(path: outputPath()).architectures(), ["arm64"])
+    }
+    
+    private func inputPath() -> Path {
+        return (Path(#file) + "../../../Fixtures/iOSFramework/Test.framework")
+        
+    }
+    
+    private func outputPath() -> Path {
+        return (tmpPath + "Test.framework")
+    }
+
+}


### PR DESCRIPTION
## Specs
Add a command for stripping architectures from frameworks.

## Implementation
- [x] Implement the command.
- [x] Hook the command from `main.swift`.
- [x] Add integration tests.

Resolves https://github.com/swift-xcode/xcode/issues/5