### PR TITLE
Command to build universal frameworks

### DIFF
--- a/Sources/Core/System.swift
+++ b/Sources/Core/System.swift
@@ -11,4 +11,12 @@ public struct System {
         return run(which(command: "xcrun", defaultPath: "/usr/bin/xcrun"), args)
     }
     
+    /// Executes xcodebuild.
+    ///
+    /// - Parameter args: arguments to be passed to xcodebuild.
+    /// - Returns: execution output.
+    public static func xcodebuild(_ args: Any ...) -> RunOutput {
+        return run(which(command: "xcodebuild", defaultPath: "/usr/bin/xcodebuild"), args)
+    }
+    
 }

--- a/Sources/Frameworks/BuildUniversal.swift
+++ b/Sources/Frameworks/BuildUniversal.swift
@@ -1,3 +1,5 @@
+// Reference https://medium.com/@syshen/create-an-ios-universal-framework-148eb130a46c
+// Reference http://arsenkin.com/ios-universal-framework.html
 import Foundation
 import PathKit
 import Core
@@ -16,23 +18,51 @@ public class BuildUniversal {
     /// Scheme that builds the framework.
     private let scheme: String
     
+    /// Configuration to build.
+    private let config: String
+    
     // MARK: - Init
     
     public init(workspace: Path? = nil,
                 project: Path? = nil,
-                scheme: String) {
+                scheme: String,
+                config: String) {
         self.workspace = workspace
         self.project = project
         self.scheme = scheme
+        self.config = config
     }
     
-    // MARK: - Func
+    // MARK: - Public
     
     /// Executes the command.
     ///
     /// - Throws: an error if the framework cannot be built
     public func execute() throws {
+        let simulatorBuildOutput = System.xcodebuild(projectParameter(),
+                                                     "-scheme", scheme,
+                                                     "-sdk", "iphonesimulator",
+                                                     "-config", config,
+                                                     "ONLY_ACTIVE_ARCH=NO",
+                                                     "clean build")
+        let deviceBuildOutput = System.xcodebuild(projectParameter(),
+                                                  "-scheme", scheme,
+                                                  "-sdk", "iphoneos",
+                                                  "-config", config,
+                                                  "ONLY_ACTIVE_ARCH=NO",
+                                                  "clean build")
 
+    }
+    
+    // MARK: - Private
+    
+    private func projectParameter() -> String {
+        if let workspace = workspace {
+            return "-workspace \(workspace.string)"
+        } else if let project = project {
+            return "-project \(project.string)"
+        }
+        return ""
     }
     
 }

--- a/Sources/Frameworks/BuildUniversal.swift
+++ b/Sources/Frameworks/BuildUniversal.swift
@@ -1,0 +1,38 @@
+import Foundation
+import PathKit
+import Core
+
+/// Builds an universal framework for device & simulator
+public class BuildUniversal {
+    
+    // MARK: - Attributes
+    
+    /// Workspace that contains the framework to build.
+    private let workspace: Path?
+    
+    /// Project that contains the framework to build.
+    private let project: Path?
+    
+    /// Scheme that builds the framework.
+    private let scheme: String
+    
+    // MARK: - Init
+    
+    public init(workspace: Path? = nil,
+                project: Path? = nil,
+                scheme: String) {
+        self.workspace = workspace
+        self.project = project
+        self.scheme = scheme
+    }
+    
+    // MARK: - Func
+    
+    /// Executes the command.
+    ///
+    /// - Throws: an error if the framework cannot be built
+    public func execute() throws {
+
+    }
+    
+}

--- a/Sources/Frameworks/StripCommand.swift
+++ b/Sources/Frameworks/StripCommand.swift
@@ -26,7 +26,7 @@ public class StripCommand {
         self.architecturesToStrip = architecturesToStrip
     }
     
-    // MARK: - Func
+    // MARK: - Public
     
     /// Executes the command.
     ///

--- a/Sources/xcode/main.swift
+++ b/Sources/xcode/main.swift
@@ -30,14 +30,17 @@ Group {
             try StripCommand(packagePath: Path(path), architecturesToStrip: Set(archs.components(separatedBy: ","))).execute()
         }
         let buildUniversal = command(Option("scheme", "", flag: "s", description: "The scheme tha builds the framework"),
+                                     Option("config", "Debug", flag: "c", description: "The configuration to build"),
                                      Option("project", "", flag: "p", description: "The path to the project that contains the framework that will be build"),
-                                     Option("workspace", "", flag: "w", description: "The path to the workspace that contains the framework that will be build")) { (scheme: String, project: String, workspace: String) in
+                                     Option("workspace", "", flag: "w", description: "The path to the workspace that contains the framework that will be build")) { (scheme: String, project: String, workspace: String, config: String) in
                                         try BuildUniversal(workspace: (workspace.isEmpty) ? nil : Path(workspace),
                                                            project: (project.isEmpty) ? nil : Path(project),
-                                                           scheme: scheme).execute()
+                                                           scheme: scheme,
+                                                           config: config).execute()
         }
         frameworks.addCommand("embed", "embeds frameworks into the product /Frameworks folder", embedCommand)
         frameworks.addCommand("strip", "strip architectures from a given framework", stripCommand)
+        frameworks.addCommand("build-universal", "build the given framework for device and simulator, merging them using lipo", stripCommand)
     }
     }.run()
 // swiftlint:enable line_length

--- a/Sources/xcode/main.swift
+++ b/Sources/xcode/main.swift
@@ -29,6 +29,13 @@ Group {
                                    Option("archs", "", flag: "a", description: "Comma separated list of architectures to strip (e.g. armv7,arm64)")) { (path: String, archs: String) in
             try StripCommand(packagePath: Path(path), architecturesToStrip: Set(archs.components(separatedBy: ","))).execute()
         }
+        let buildUniversal = command(Option("scheme", "", flag: "s", description: "The scheme tha builds the framework"),
+                                     Option("project", "", flag: "p", description: "The path to the project that contains the framework that will be build"),
+                                     Option("workspace", "", flag: "w", description: "The path to the workspace that contains the framework that will be build")) { (scheme: String, project: String, workspace: String) in
+                                        try BuildUniversal(workspace: (workspace.isEmpty) ? nil : Path(workspace),
+                                                           project: (project.isEmpty) ? nil : Path(project),
+                                                           scheme: scheme).execute()
+        }
         frameworks.addCommand("embed", "embeds frameworks into the product /Frameworks folder", embedCommand)
         frameworks.addCommand("strip", "strip architectures from a given framework", stripCommand)
     }


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/xcodeproj/issues/7)
Resolves https://github.com/swift-xcode/xcode/issues/7

### Short description
The command builds a framework for device and simulator merging them using lipo. This is useful to generate frameworks that can be distributed.

### Solution
Implement the command and hook it from the CLI definition.

### Implementation
- [x] Hook command.
- [ ] Implement command.
- [ ] Test command. 

### GIF
![gif](https://media.giphy.com/media/3o8dFsli7WHrejm1Jm/giphy.gif)